### PR TITLE
Modernize the build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ picosFILES/nohup*
 picosFiles/MPEX_*
 *.fig
 picosFILES/*.csv
+ARMADILLO
+BOOST_MATH
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,129 @@
+cmake_minimum_required (VERSION 3.14)
+
+project (picos CXX)
+
+#-------------------------------------------------------------------------------
+#  Build Options
+#-------------------------------------------------------------------------------
+option (USE_PCH "Enable the use of precompiled headers" ON)
+option (USE_HDF5_DOUBLE "Save hdf5 files as double. When off uses float" OFF)
+
+#-------------------------------------------------------------------------------
+#  Set the cmake module path.
+#-------------------------------------------------------------------------------
+set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+#-------------------------------------------------------------------------------
+#  Setup build types
+#-------------------------------------------------------------------------------
+if (NOT CMAKE_BUILD_TYPE)
+    set (CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+endif ()
+set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+              Debug
+              Release
+              MinSizeRel
+              RelWithDebInfo
+)
+
+#-------------------------------------------------------------------------------
+#  Sanitizer options
+#-------------------------------------------------------------------------------
+add_library (sanitizer INTERFACE)
+target_compile_options (sanitizer
+                        INTERFACE
+                        $<$<CONFIG:Sanitized>:-g>
+)
+
+macro (register_sanitizer_option name)
+    string (TOUPPER ${name} upper_name)
+
+    option (SANITIZE_${upper_name} "Enable the ${name} sanitizer" OFF)
+
+    target_compile_options (sanitizer
+                            INTERFACE
+                            $<$<BOOL:${SANITIZE_${upper_name}}>:-fsanitize=${name}>
+    )
+    target_link_options (sanitizer
+                         INTERFACE
+                         $<$<BOOL:${SANITIZE_${upper_name}}>:-fsanitize=${name}>
+    )
+endmacro ()
+
+register_sanitizer_option (address)
+register_sanitizer_option (leak)
+register_sanitizer_option (memory)
+register_sanitizer_option (thread)
+register_sanitizer_option (undefined)
+register_sanitizer_option (float-divide-by-zero)
+
+#-------------------------------------------------------------------------------
+#  Setup access method.
+#-------------------------------------------------------------------------------
+option (USE_SSH "Use ssh to access git repos" OFF)
+if (${USE_SSH})
+    set (URL_PROTO "git@")
+    set (URL_SEP ":")
+else ()
+    set (URL_PROTO "https://")
+    set (URL_SEP "/")
+endif ()
+
+#-------------------------------------------------------------------------------
+#  Define a macro to register new projects.
+#-------------------------------------------------------------------------------
+include (FetchContent)
+find_package (Git)
+
+function (register_project reg_name dir url default_tag)
+    set (BUILD_TAG_${dir} ${default_tag} CACHE STRING "Name of the tag to checkout.")
+
+    FetchContent_Declare (
+        ${reg_name}
+        GIT_REPOSITORY ${url}
+        GIT_TAG origin/${BUILD_TAG_${dir}}
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${dir}
+    )
+
+    FetchContent_MakeAvailable (${reg_name})
+
+    if (${GIT_FOUND})
+#  By default cmake clones projects in a headless state. After the repo is
+#  cloned checkout the requested tag so repo is in a working state.
+        execute_process (
+            COMMAND ${GIT_EXECUTABLE} checkout ${BUILD_TAG_${dir}}
+            WORKING_DIRECTORY ${${reg_name}_SOURCE_DIR}
+        )
+
+#  Add a taraget to pull the latest version before building. Note dependency is
+#  registered in the sub project CMakeList.txt. Not sure how this should handle
+#  multiple targets in a project yet. Name must match the subproject pull_
+#  dependency.
+        add_custom_target (
+            pull_${reg_name}
+            ALL
+            COMMAND ${GIT_EXECUTABLE} pull
+            WORKING_DIRECTORY ${${reg_name}_SOURCE_DIR}
+        )
+    endif ()
+endfunction ()
+
+register_project (armadillo
+                  ARMADILLO
+                  ${URL_PROTO}gitlab.com${URL_SEP}conradsnicta/armadillo-code.git
+                  15.2.x
+)
+add_dependencies (armadillo pull_armadillo)
+
+#-------------------------------------------------------------------------------
+#  External dependencies.
+#-------------------------------------------------------------------------------
+find_package (OpenMP)
+find_package (MPI REQUIRED)
+find_package (Bessel)
+find_package (HDF5 MODULE REQUIRED COMPONENTS C CXX)
+
+#-------------------------------------------------------------------------------
+#  Setup targets
+#-------------------------------------------------------------------------------
+add_subdirectory (picosFILES)

--- a/cmake/FindBessel.cmake
+++ b/cmake/FindBessel.cmake
@@ -1,0 +1,43 @@
+#[==[
+Provides the following variables:
+
+  * `Bessel::Bessel`: A target to use with `target_link_libraries`.
+#]==]
+
+include (CheckCXXSourceCompiles)
+
+check_cxx_source_compiles ("
+#include <cmake>
+
+void foo() {
+    std::cyl_bessel_j(1,1);
+}
+" HAS_BESSEL)
+
+add_library (Bessel INTERFACE)
+
+if (HAS_BESSEL)
+    target_compile_definitions (Bessel
+
+                                INTERFACE
+
+                                HAS_STD_BESSEL
+                                CYL_BESSEL_J=std::cyl_bessel_j
+    )
+else ()
+    register_project (boost_math
+                      BOOST_MATH
+                      ${URL_PROTO}github.com${URL_SEP}boostorg/math.git
+                      develop
+    )
+    add_dependencies (boost_math pull_boost_math)
+
+    target_link_libraries (Bessel INTERFACE Boost::math)
+    target_compile_definitions (Bessel
+
+                                INTERFACE
+
+                                CYL_BESSEL_J=boost::math::cyl_bessel_j
+    )
+endif ()
+add_library (Bessel::Bessel ALIAS Bessel)

--- a/picosFILES/CMakeLists.txt
+++ b/picosFILES/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory (src)

--- a/picosFILES/src/CMakeLists.txt
+++ b/picosFILES/src/CMakeLists.txt
@@ -1,0 +1,62 @@
+add_executable (xpicos)
+
+target_compile_features (xpicos
+
+                         PRIVATE
+
+                         cxx_std_23
+)
+target_compile_definitions (xpicos
+
+                            PRIVATE
+
+                            $<$<BOOL:${USE_HDF5_DOUBLE}>:HDF5_DOUBLE>
+                            $<$<BOOL:${USE_HDF5_DOUBLE}>:HDF5_FLOAT>
+)
+target_sources (xpicos
+
+                PRIVATE
+
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fieldSolve.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/main.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/outputHDF5.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/rfOperator.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/collisionOperator.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/initialize.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mpi_main.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/PIC.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/units.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/initDistribution.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/particleBC.cpp>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/types.cpp>
+)
+
+target_precompile_headers (xpicos
+
+                           PRIVATE
+
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/initDistribution.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/particleBC.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/types.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fieldSolve.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/outputHDF5.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/rfOperator.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/collisionOperator.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/initialize.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mpi_main.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/PIC.h>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/units.h>
+)
+
+target_link_libraries (xpicos
+
+                       PRIVATE
+
+                       sanitizer
+                       armadillo
+                       $<$<BOOL:${OpenMP_CXX_FOUND}>:OpenMP::OpenMP_CXX>
+                       MPI::MPI_CXX
+                       Bessel::Bessel
+                       hdf5::hdf5
+                       hdf5::hdf5_cpp
+)

--- a/picosFILES/src/PIC.h
+++ b/picosFILES/src/PIC.h
@@ -22,7 +22,6 @@
 #include "types.h"
 
 // Parallelization libraries:
-#include <omp.h>
 #include "mpi_main.h"
 
 using namespace std;

--- a/picosFILES/src/collisionOperator.h
+++ b/picosFILES/src/collisionOperator.h
@@ -10,7 +10,6 @@
 #include "armadillo"
 #include "types.h"
 #include "mpi_main.h"
-#include "omp.h"
 
 using namespace std;
 using namespace arma;

--- a/picosFILES/src/main.cpp
+++ b/picosFILES/src/main.cpp
@@ -23,7 +23,6 @@
 
 // Include headers for parallelization:
 // =============================================================================
-#include <omp.h>
 #include "mpi_main.h"
 
 using namespace std;

--- a/picosFILES/src/mpi_main.h
+++ b/picosFILES/src/mpi_main.h
@@ -5,7 +5,6 @@
 #include <vector>
 #define ARMA_ALLOW_FAKE_GCC
 #include <armadillo>
-#include <omp.h>
 #include <cmath>
 
 #include "types.h"

--- a/picosFILES/src/outputHDF5.h
+++ b/picosFILES/src/outputHDF5.h
@@ -14,7 +14,7 @@
 #include <armadillo>
 #include "types.h"
 
-#include "H5Cpp.h"
+#include <H5Cpp.h>
 
 using namespace H5;
 using namespace std;
@@ -26,10 +26,11 @@ class HDF_TYP
 	#ifdef HDF5_DOUBLE
 		#define HDF_TYPE PredType::NATIVE_DOUBLE
 		#define CPP_TYPE double
-	#elif defined HDF5_FLOAT
-		#define HDF_TYPE PredType::NATIVE_FLOAT
-		#define CPP_TYPE float
-	#endif
+    #else
+        #define HDF5_FLOAT
+        #define HDF_TYPE PredType::NATIVE_FLOAT
+        #define CPP_TYPE float
+    #endif
 
 	void saveToHDF5(H5File * file, string name, int * value);
 

--- a/picosFILES/src/particleBC.h
+++ b/picosFILES/src/particleBC.h
@@ -9,7 +9,6 @@
 #include "armadillo"
 #include "types.h"
 #include "mpi_main.h"
-#include "omp.h"
 
 using namespace std;
 using namespace arma;

--- a/picosFILES/src/rfOperator.cpp
+++ b/picosFILES/src/rfOperator.cpp
@@ -1,5 +1,9 @@
 #include "rfOperator.h"
 
+#ifndef HAS_STD_BESSEL
+#include <boost/math/special_functions/bessel.hpp>
+#endif
+
 RF_Operator_TYP::RF_Operator_TYP(params_TYP * params, CS_TYP * CS, fields_TYP * fields, vector<ionSpecies_TYP> * IONS)
 {
     if (params->mpi.COMM_COLOR == PARTICLES_MPI_COLOR)
@@ -145,8 +149,8 @@ void RF_Operator_TYP::calculateRfTerms(int ii, params_TYP * params, CS_TYP * CS,
     // Calculate bessel terms:
     rL  = vper/Omega;
     flr = kper*rL;
-    J_nm1 = std::cyl_bessel_j(n - 1,flr);
-    J_np1 = std::cyl_bessel_j(n + 1,flr);
+    J_nm1 = CYL_BESSEL_J(n - 1,flr);
+    J_np1 = CYL_BESSEL_J(n + 1,flr);
 
     /*
     cout << "rL = " << rL*CS->length << endl;

--- a/picosFILES/src/rfOperator.h
+++ b/picosFILES/src/rfOperator.h
@@ -9,7 +9,6 @@
 #include "armadillo"
 #include "types.h"
 #include "mpi_main.h"
-#include "omp.h"
 
 using namespace std;
 using namespace arma;

--- a/picosFILES/src/types.h
+++ b/picosFILES/src/types.h
@@ -9,7 +9,9 @@
 #include <string>
 #include <map>
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 #include "mpi.h"
 
 using namespace std;


### PR DESCRIPTION
This pull request modernizes the CMake build system and allows it to work on a default macOS install. New features include, 

- Auto detection for Bessel function in the standard library with a fallback to Boost is they don't exist.
- Auto section for MPI, OpenMP, and HDF5
- Automatically clones and compiles Armadillo
- Adds Sanitizer options for debugging.

This also fixes several issues with includes and remove duplicate or unnecessary files.

To use the cmake build system you can first need to install [cmake](https://cmake.org). In the root directory of PICOS, create a build directory then navigate to it.

```
mkdir build
cd build
```

Run either
```
cmake ../
```
or for an interactive GUI to set options run
```
ccmake ../
```

Once cmake is configured, the code can be built using make.
```
make
```

The PICOS executable called `xpicos` will be located in 
```
PICOS_ROOT\build\picosFILES/src
```